### PR TITLE
Directory may exist

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -145,9 +145,15 @@ func (t *Tlib) ConstructDir() func() {
 	mockdir := filepath.Join(t.mockdir, t.subdir)
 	err = Mkdir(mockdir)
 	if err != nil {
-		log.Fatalf("ConstructDir Failed: %s\n", err)
+		log.Printf("ConstructDir Failed: %s\n", err)
 	}
-	os.Chdir(mockdir)
+	err = os.Chdir(mockdir)
+	if err != nil {
+		log.Printf("os.Chdir(%s) failed\n", mockdir)
+		log.Printf("mockdir: %s\n", mockdir)
+		log.Fatalf("can't Chdir. Error: %s\n", err)
+
+	}
 
 	return func() {
 		os.Chdir(old)


### PR DESCRIPTION
Don't fail if directory can't be created.  Instead, just log an error.  Fail only if chdir fails, since the directory may exist.